### PR TITLE
Adding Group potluck/Model Change

### DIFF
--- a/potluck-app/potluck/Components/Potluck/AddMoney/AddMoney.js
+++ b/potluck-app/potluck/Components/Potluck/AddMoney/AddMoney.js
@@ -49,7 +49,7 @@ export default class AddMoney extends Component<Props> {
     }else{
       this.setState({
         newAmount: (Number.parseInt(amountAdded)+Number.parseInt(this.props.userPotluckInfo.amount))
-      },   ()=>{this.props.onAddMoney(this.state.newAmount, this.props.userID)});
+      },   ()=>{this.props.onAddMoney(this.state.newAmount, this.props.username)});
       this.setState({
         amountAdded: ''
       })

--- a/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckGroup.js
+++ b/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckGroup.js
@@ -12,6 +12,7 @@ import {
 import PropTypes from 'prop-types';
 import t from 'tcomb-form-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import moment from 'moment';
 
 const Potluck = t.struct({
   potluckName: t.String,
@@ -20,6 +21,10 @@ const Potluck = t.struct({
   pricePerPerson: t.Number,
   dateDue: t.Date
 });
+
+let myFormatFunction = (format,date) =>{
+            return moment(date).format(format);
+        }
 
 const options = {
   fields: {
@@ -36,7 +41,11 @@ const options = {
       label: 'How much is each person paying?'
     },
     dateDue:{
-      label: 'Due Date'
+      label: 'Due Date',
+      mode: 'date',
+      config:{
+                format:(date) => myFormatFunction("DD MMM YYYY",date)
+    }
     }
   },
 };
@@ -48,11 +57,6 @@ export default class AddPotluckGroup extends Component<Props> {
 
   static defaultProps = {
   };
-
-
-  printSomething(){
-    console.log("YOO")
-  }
 
   constructor(props){
     super(props);
@@ -67,6 +71,21 @@ export default class AddPotluckGroup extends Component<Props> {
     }
   }
 
+  validateMemberForm(memberList){
+    for(var i = 0;i<memberList.length;i++){
+      if(memberList[i].username.length==0 || memberList[i].name.length==0){
+        Alert.alert(
+          'Missing value for member',
+          'Please add name and username for member',
+          {cancelable: true}
+        )
+        return false;
+      }
+    }
+    return true;
+
+  }
+
   onPress(){
     loggedInUserMemberInfo = {
         username: this.props.loggedInUser.username,
@@ -77,7 +96,7 @@ export default class AddPotluckGroup extends Component<Props> {
 
     memberList = this.state.members.concat(loggedInUserMemberInfo)
     var value = this.refs.form.getValue();
-    if (value) {
+    if (value && this.validateMemberForm(memberList)) {
       newPotluck = {
 		"members": memberList,
 		"potluckName": value.potluckName,
@@ -85,11 +104,11 @@ export default class AddPotluckGroup extends Component<Props> {
 		"isGroupPotluck": true,
 		"showPercentage": value.showPercentage,
 		"pricePerPerson": value.pricePerPerson,
-		"dateDue": value.dateDue,
+		"dateDue": moment(value.dateDue).format("YYYY-MM-DD"),
 		"adminUsername": this.props.loggedInUser.username,
-		"numberOfUsers": 1
-      // clear all fields after submit
+		"numberOfUsers": memberList.length
     }
+    this.addPotluck(newPotluck)
     }
   }
 
@@ -97,10 +116,6 @@ export default class AddPotluckGroup extends Component<Props> {
     this.setState({
       members: this.state.members.filter((s, sidx) => memberID !== sidx)
     });
-  }
-
-  getMemberInfo(){
-
   }
 
   handleMemberChangeUsername(text,idx) {
@@ -120,6 +135,8 @@ export default class AddPotluckGroup extends Component<Props> {
 
     this.setState({ members: newMembers });
   }
+
+
 
 
   handleAddMember(){
@@ -145,11 +162,12 @@ export default class AddPotluckGroup extends Component<Props> {
       'content-type': 'application/json'
       },
     }
-  ).then(function(response){
+  ).then((response) => {
       if(response.ok){
-        console.log(response)
+        this.props.goBackToHome()
       }
     })
+
 
   }
 
@@ -160,6 +178,7 @@ export default class AddPotluckGroup extends Component<Props> {
       return (
         <View style = {styles.container}>
         <KeyboardAwareScrollView contentContainerStyle={styles.main}>
+          <Text style={styles.screenTitle}>Add a Group Potluck</Text>
         <Form
           value={this.state.value}
         ref="form"
@@ -193,10 +212,6 @@ export default class AddPotluckGroup extends Component<Props> {
 }
 
 const styles = StyleSheet.create({
-  name:{
-    fontWeight: 'bold'
-
-  },
   container:{
     alignItems: 'center',
     paddingBottom:10,
@@ -205,8 +220,7 @@ const styles = StyleSheet.create({
   },
   createPotluckButton:{
     alignItems: 'center',
-    padding: 10,
-    marginTop:10,
+    padding: 5,
     backgroundColor:'#00FF00'
   },
   textInput: {
@@ -214,7 +228,15 @@ const styles = StyleSheet.create({
     width: 100,
     height:30,
     borderBottomWidth: 3
+  },
+  screenTitle:{
+    alignItems: 'center',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    padding: 8,
+    fontSize: 20,
   }
+
 });
 
 AddPotluckGroup.propTypes = {

--- a/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckGroup.js
+++ b/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckGroup.js
@@ -57,18 +57,84 @@ export default class AddPotluckGroup extends Component<Props> {
   constructor(props){
     super(props);
     this.state = {
-      isHiddenGroupPotluckFields: true,
-      randomText: "FALSE"
+      members:[{
+        username: '',
+        name: '',
+        amount: 0,
+        isAdmin: false
+
+      }]
     }
   }
 
   onPress(){
+    loggedInUserMemberInfo = {
+        username: this.props.loggedInUser.username,
+        name: this.props.loggedInUser.name,
+        amount: 0,
+        isAdmin: true
+      }
+
+    memberList = this.state.members.concat(loggedInUserMemberInfo)
     var value = this.refs.form.getValue();
     if (value) {
-      console.log(value);
-      console.log("Logged in User:" + this.props.loggedInUser.name)
+      newPotluck = {
+		"members": memberList,
+		"potluckName": value.potluckName,
+		"potluckDescription": value.potluckDescription,
+		"isGroupPotluck": true,
+		"showPercentage": value.showPercentage,
+		"pricePerPerson": value.pricePerPerson,
+		"dateDue": value.dateDue,
+		"adminUsername": this.props.loggedInUser.username,
+		"numberOfUsers": 1
       // clear all fields after submit
     }
+    }
+  }
+
+  handleDeleteMember(memberID){
+    this.setState({
+      members: this.state.members.filter((s, sidx) => memberID !== sidx)
+    });
+  }
+
+  getMemberInfo(){
+
+  }
+
+  handleMemberChangeUsername(text,idx) {
+    const newMembers = this.state.members.map((member, midx) => {
+      if (idx !== midx) return member;
+      return { ...member, username: text };
+    });
+
+    this.setState({ members: newMembers });
+  }
+
+  handleMemberChangeName(text,idx) {
+    const newMembers = this.state.members.map((member, midx) => {
+      if (idx !== midx) return member;
+      return { ...member, name: text };
+    });
+
+    this.setState({ members: newMembers });
+  }
+
+
+  handleAddMember(){
+    this.setState({
+      members: this.state.members.concat([{
+        username: '',
+        name: '',
+        amount: 0,
+        isAdmin: false
+      }])
+    });
+  }
+
+  onFormChange(value) {
+    this.setState({value});
   }
 
   addPotluck(newPotluck){
@@ -87,16 +153,33 @@ export default class AddPotluckGroup extends Component<Props> {
 
   }
 
+
+
   render() {
 
       return (
         <View style = {styles.container}>
         <KeyboardAwareScrollView contentContainerStyle={styles.main}>
         <Form
+          value={this.state.value}
         ref="form"
         type={Potluck}
         options = {options}
+        onChange={(text) => this.onFormChange(text)}
         />
+      <Text>Members:</Text>
+      {this.state.members.map((member, idx)=>(
+        <View key ={idx}>
+        <TextInput type="text" placeholder={`Member's #${idx + 1} username`} onChangeText={ (text) => this.handleMemberChangeUsername(text,idx)}/>
+          <TextInput type="text" placeholder={`Member's #${idx + 1} name`} onChangeText={ (text) => this.handleMemberChangeName(text,idx)}/>
+          <TouchableHighlight onPress={this.handleDeleteMember.bind(this, idx)} underlayColor='#99d9f4'>
+            <Text style={styles.buttonText}>-</Text>
+          </TouchableHighlight>
+        </View>
+          ))}
+          <TouchableHighlight onPress={this.handleAddMember.bind(this)} underlayColor='#99d9f4'>
+            <Text style={styles.buttonText}>Add Member</Text>
+          </TouchableHighlight>
         <View style={styles.createPotluckButton}>
         <TouchableHighlight onPress={this.onPress.bind(this)} underlayColor='#99d9f4'>
           <Text style={styles.buttonText}>Create Potluck</Text>
@@ -122,7 +205,8 @@ const styles = StyleSheet.create({
   },
   createPotluckButton:{
     alignItems: 'center',
-    padding: 5,
+    padding: 10,
+    marginTop:10,
     backgroundColor:'#00FF00'
   },
   textInput: {

--- a/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckPersonal.js
+++ b/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckPersonal.js
@@ -12,6 +12,7 @@ import {
 import PropTypes from 'prop-types';
 import t from 'tcomb-form-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import moment from 'moment';
 
 const Potluck = t.struct({
   potluckName: t.String,
@@ -19,6 +20,10 @@ const Potluck = t.struct({
   pricePerPerson: t.Number,
   dateDue: t.Date
 });
+
+let myFormatFunction = (format,date) =>{
+            return moment(date).format(format);
+        }
 
 const options = {
   fields: {
@@ -32,7 +37,11 @@ const options = {
       label: 'How much is the goal?'
     },
     dateDue:{
-      label: 'Due Date'
+      label: 'Due Date',
+      mode: 'date',
+      config:{
+                format:(date) => myFormatFunction("DD MMM YYYY",date)
+    }
     }
   },
 };
@@ -75,7 +84,7 @@ export default class AddPotluckPersonal extends Component<Props> {
 		"isGroupPotluck": false,
 		"showPercentage": false,
 		"pricePerPerson": value.pricePerPerson,
-		"dateDue": value.dateDue,
+    "dateDue": moment(value.dateDue).format("YYYY-MM-DD"),
 		"adminUsername": this.props.loggedInUser.username,
 		"numberOfUsers": 1
       // clear all fields after submit
@@ -106,6 +115,7 @@ export default class AddPotluckPersonal extends Component<Props> {
       return (
         <View style = {styles.container}>
         <KeyboardAwareScrollView contentContainerStyle={styles.main}>
+          <Text style={styles.screenTitle}>Add a Personal Potluck</Text>
         <Form
         ref="form"
         type={Potluck}
@@ -124,20 +134,11 @@ export default class AddPotluckPersonal extends Component<Props> {
 }
 
 const styles = StyleSheet.create({
-  name:{
-    fontWeight: 'bold'
-
-  },
   container:{
     alignItems: 'center',
     paddingBottom:10,
     paddingTop:10
 
-  },
-  addButton:{
-    fontSize: 20,
-    padding: 5,
-    backgroundColor:'#00FF00'
   },
   textInput: {
     borderColor: 'black',
@@ -149,6 +150,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 5,
     backgroundColor:'#00FF00'
+  },
+  screenTitle:{
+    alignItems: 'center',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    padding: 8,
+    fontSize: 20,
   }
 });
 

--- a/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckPersonal.js
+++ b/potluck-app/potluck/Components/Potluck/AddPotluck/AddPotluckPersonal.js
@@ -61,12 +61,10 @@ export default class AddPotluckPersonal extends Component<Props> {
   onPress(){
     var value = this.refs.form.getValue();
     if (value) {
-      console.log(value);
-      console.log("Logged in User:" + this.props.loggedInUser.name)
       newPotluck = {
 		"members": [
         {
-				"accountID": this.props.loggedInUser.accountID,
+				"username": this.props.loggedInUser.username,
 				"name": this.props.loggedInUser.name,
 				"amount": 0,
 				"isAdmin": true
@@ -78,7 +76,7 @@ export default class AddPotluckPersonal extends Component<Props> {
 		"showPercentage": false,
 		"pricePerPerson": value.pricePerPerson,
 		"dateDue": value.dateDue,
-		"adminID": this.props.loggedInUser.accountID,
+		"adminUsername": this.props.loggedInUser.username,
 		"numberOfUsers": 1
       // clear all fields after submit
     }

--- a/potluck-app/potluck/Components/Potluck/ViewPotluck/PersonalProgress.js
+++ b/potluck-app/potluck/Components/Potluck/ViewPotluck/PersonalProgress.js
@@ -32,7 +32,8 @@ export default class PersonalProgress extends Component<Props> {
 
   render() {
     let memberName = this.props.userPotluckInfo.name;
-    let accountID = this.props.userPotluckInfo.accountID;
+    let username = this.props.userPotluckInfo.username;
+    console.log(username)
     let amount = this.props.userPotluckInfo.amount;
     let pricePerPerson = this.props.pricePerPerson;
     var amountProgress = this.calculateProgress(amount,pricePerPerson);

--- a/potluck-app/potluck/Components/Potluck/ViewPotluck/PotluckProgressItemYN.js
+++ b/potluck-app/potluck/Components/Potluck/ViewPotluck/PotluckProgressItemYN.js
@@ -43,7 +43,7 @@ export default class PotluckProgressItemYN extends Component<Props> {
       return (
           <View style={styles.container}>
             <Text style={styles.name}>{this.props.member.name}:</Text>
-             <Text> <Text style={this.progressStyling(completedGoal)}>{completedGoal}</Text>             {amount}</Text>
+             <Text> <Text style={this.progressStyling(completedGoal)}>{completedGoal}</Text></Text>
           </View>
         );
   }

--- a/potluck-app/potluck/Components/Potluck/ViewPotluck/ViewPotluck.js
+++ b/potluck-app/potluck/Components/Potluck/ViewPotluck/ViewPotluck.js
@@ -27,8 +27,8 @@ export default class ViewPotluck extends Component<Props> {
 
 
 
-  addMoney(newAmount, userID){
-    this.props.addMoney(newAmount,userID)
+  addMoney(newAmount, username){
+    this.props.addMoney(newAmount,username)
   }
 
   constructor(props){
@@ -46,10 +46,9 @@ export default class ViewPotluck extends Component<Props> {
     let members = this.props.potluck.members;
     let pricePerPerson = this.props.potluck.pricePerPerson;
     let dateDue = this.props.potluck.dateDue;
-    let adminID = this.props.potluck.adminID;
     let potluckName = this.props.potluck.potluckName;
     let potluckDescription = this.props.potluck.potluckDescription;
-    let userID = this.props.user.accountID;
+    let userUsername = this.props.user.username;
     let groupSize = members.length;
     let numberOfUsers = this.props.potluck.numberOfUsers
 
@@ -57,53 +56,59 @@ export default class ViewPotluck extends Component<Props> {
     let progressComponent;
     let progressYouComponent;
 
-    let userPotluckInfo;
+    let userPotluckInfo={
+				"username": "placeholder",
+				"name": "placeholder",
+				"amount": 0,
+				"isAdmin": true
+			};
+
     members.map(member=>{
-      if(member.accountID==userID)
+      if(member.username==userUsername)
         userPotluckInfo = member;
     })
 
+    if(userPotluckInfo)
+      if(isGroupPotluck){
+        if(!showPercentage){
+          progressItems = members.map(member=>{
+
+            if(userUsername!=member.username){
+              return(<PotluckProgressItemYN isUser={false}member={member} key={member.username} pricePerPerson={pricePerPerson}/>)
+            }else{
+              member.name = "You"
+              progressYouComponent = <PotluckProgressItemYN isUser={true}  member={member} key={member.username} pricePerPerson={pricePerPerson}/>
+            }
+
+          })
+          progressItems.push(progressYouComponent)
+          progressComponent =
+            <View style={styles.progress}>
+              {progressItems}
+            </View>
 
 
-    if(isGroupPotluck){
-      if(!showPercentage){
-        progressItems = members.map(member=>{
+        }else{
+          progressItems = members.map(member=>{
 
-          if(userID!=member.accountID){
-            return(<PotluckProgressItemYN isUser={false}member={member} key={member.accountID} pricePerPerson={pricePerPerson}/>)
-          }else{
-            member.name = "You"
-            progressYouComponent = <PotluckProgressItemYN isUser={true}  member={member} key={member.accountID} pricePerPerson={pricePerPerson}/>
-          }
+            if(userUsername!=member.username){
+              return(<PotluckProgressItemPercentage   isUser={false}member={member} key={member.username} pricePerPerson={pricePerPerson}/>)
+            }
 
-        })
-        progressItems.push(progressYouComponent)
-        progressComponent =
-          <View style={styles.progress}>
+          })
+          progressComponent =
+            <View style={styles.progress}>
             {progressItems}
-          </View>
+            </View>
 
-
+        }
       }else{
-        progressItems = members.map(member=>{
-          if(userID!=member.accountID){
-            return(<PotluckProgressItemPercentage   isUser={false}member={member} key={member.accountID} pricePerPerson={pricePerPerson}/>)
-          }
-
-        })
-        progressComponent =
-          <View style={styles.progress}>
-          {progressItems}
+        progressComponent = [
+          <View style={styles.progress} key="personalProgress">
+            <Text>Personal Progress Screen</Text>
           </View>
-
+        ]
       }
-    }else{
-      progressComponent =
-        <View style={styles.progress}>
-          <Text>Personal Progress Screen</Text>
-        </View>
-
-    }
 
     return(
         <View style = {styles.container}>
@@ -114,7 +119,7 @@ export default class ViewPotluck extends Component<Props> {
           {progressComponent}
           <PersonalProgress   userPotluckInfo={userPotluckInfo} pricePerPerson={pricePerPerson}/>
           <View style ={styles.addMoney}>
-            <AddMoney onAddMoney={this.addMoney.bind(this)} userID={userID} userPotluckInfo={userPotluckInfo} pricePerPerson={pricePerPerson}/>
+            <AddMoney onAddMoney={this.addMoney.bind(this)} username={userUsername}userPotluckInfo={userPotluckInfo} pricePerPerson={pricePerPerson}/>
           </View>
           </KeyboardAwareScrollView>
 

--- a/potluck-app/potluck/Screens/AddPotluckScreen.js
+++ b/potluck-app/potluck/Screens/AddPotluckScreen.js
@@ -19,7 +19,6 @@ export default class AddPotluckScreen extends Component<Props> {
   };
 
   static navigationOptions = {
-    title: 'Add Potluck',
   };
 
   constructor(props){

--- a/potluck-app/potluck/Screens/AddPotluckScreenGroup.js
+++ b/potluck-app/potluck/Screens/AddPotluckScreenGroup.js
@@ -8,17 +8,23 @@ import {
 } from 'react-native';
 import { StackNavigator } from 'react-navigation';
 import AddPotluckGroup from '../Components/Potluck/AddPotluck/AddPotluckGroup';
+import { NavigationActions } from 'react-navigation';
 
 export default class PotluckDetailScreen extends Component<Props> {
 
-  static navigationOptions = {
-    title: 'Add Group Potluck',
-  };
+  goBackToHome(){
+    const resetAction = NavigationActions.reset({
+      index: 0,
+      actions: [NavigationActions.navigate({ routeName: 'HomeScreen' })],
+    });
+    this.props.navigation.dispatch(resetAction);
+
+  }
 
   render(){
     return(
       <View>
-        <AddPotluckGroup loggedInUser={this.props.navigation.state.params.loggedInUser}/>
+        <AddPotluckGroup goBackToHome={this.goBackToHome.bind(this)}  loggedInUser={this.props.navigation.state.params.loggedInUser}/>
       </View>
     )
   }

--- a/potluck-app/potluck/Screens/AddPotluckScreenPersonal.js
+++ b/potluck-app/potluck/Screens/AddPotluckScreenPersonal.js
@@ -12,10 +12,6 @@ import { NavigationActions } from 'react-navigation';
 
 export default class PotluckDetailScreen extends Component<Props> {
 
-  static navigationOptions = {
-    title: 'Add Personal Potluck',
-  };
-
   goBackToHome(){
     const resetAction = NavigationActions.reset({
       index: 0,

--- a/potluck-app/potluck/Screens/HomeScreen.js
+++ b/potluck-app/potluck/Screens/HomeScreen.js
@@ -24,7 +24,7 @@ export default class HomeScreen extends Component<Props> {
 
   getPotlucks(){
     potlucks = []
-    fetch('http://localhost:5000/potlucks/accountID/0').then(function(response){
+    fetch('http://localhost:5000/potlucks/username/'+this.state.loggedInUser.username).then(function(response){
       if(response.ok){
         return response.json();
       }
@@ -42,7 +42,7 @@ export default class HomeScreen extends Component<Props> {
   constructor(props){
     super(props)
     let loggedInUser = {
-      accountID: 0,
+      username: 'intbrandon',
       name: "Brandon Cornel"
     }
     potlucks = []

--- a/potluck-app/potluck/Screens/PotluckDetailScreen.js
+++ b/potluck-app/potluck/Screens/PotluckDetailScreen.js
@@ -30,8 +30,6 @@ export default class PotluckDetailScreen extends Component<Props> {
         potluckName: response[0].potluckName,
         potluck: response[0]
       },function(){
-        console.log(this.state.potluck)
-
       })
 
 
@@ -55,7 +53,6 @@ export default class PotluckDetailScreen extends Component<Props> {
     }
   ).then(function(response){
       if(response.ok){
-        console.log(response)
       }
     })
 
@@ -70,7 +67,7 @@ export default class PotluckDetailScreen extends Component<Props> {
     let samplePotluck = {
       members :[
         {
-          accountID: 0,
+          username: "",
           name: "",
           amount: 0,
           isAdmin: true
@@ -84,7 +81,7 @@ export default class PotluckDetailScreen extends Component<Props> {
       showPercentage: true,
       pricePerPerson: 2000,
       dateDue: "",
-      adminID: 0,
+      adminUsername: "intbrandon",
       numberOfUsers: 4
 
 
@@ -98,16 +95,16 @@ export default class PotluckDetailScreen extends Component<Props> {
 
   }
 
-  findUserInGroup(userID){
+  findUserInGroup(username){
     for(var i = 0;i<this.state.potluck.members.length;i++){
-      if(this.state.potluck.members[i].accountID === userID){
+      if(this.state.potluck.members[i].username === username){
         return i;
       }
     }
   }
 
-  handleAddMoney(newAmount, userID){
-    var userIndexInPotluck = this.findUserInGroup(userID);
+  handleAddMoney(newAmount, username){
+    var userIndexInPotluck = this.findUserInGroup(username);
     var newPotluck = this.state.potluck;
     var members = newPotluck.members;
 

--- a/potluck-app/potluck/package-lock.json
+++ b/potluck-app/potluck/package-lock.json
@@ -5729,6 +5729,16 @@
         }
       }
     },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+    },
+    "momentjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/momentjs/-/momentjs-2.0.0.tgz",
+      "integrity": "sha1-c9+QS0+kGPbjxgXoMc727VUY69Q="
+    },
     "morgan": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",

--- a/potluck-app/potluck/package.json
+++ b/potluck-app/potluck/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "expo": "^25.0.0",
+    "moment": "^2.21.0",
+    "momentjs": "^2.0.0",
     "react": "^16.2.0",
     "react-native": "0.52.0",
     "react-native-elements": "^0.19.0",


### PR DESCRIPTION
*Was able to complete adding group potlucks!! Uses dynamic fields, and also does a little field verification to make sure no blank members are added to a potluck. 
-Users add members to potluck using their username. They also specify the name of the member in the potluck group.

*I also changed the model of each potluck to use usernames instead of accountIDs. This was because it's easier to add somebody as a member to the potluck using their username instead of accountID. 

**ALSO the logged in user prop is set in the homescreen screen file! It should be called loggedInUser**